### PR TITLE
Use custom link options to expose symbol aliases

### DIFF
--- a/build_linux_x64.sh
+++ b/build_linux_x64.sh
@@ -4,11 +4,13 @@ if [ ! -d "build/units_v7_x64" ]; then
     mkdir build/units_v7_x64
 fi
 fpc -Px86_64 @src/v7/linux-x64.cfg -B src/v7/dss_capi_v7.lpr
+bash custom_link.sh lib/linux_x64/v7
 
 if [ ! -d "build/units_v8_x64" ]; then
     mkdir build/units_v8_x64
 fi
 fpc -Px86_64 @src/v8/linux-x64.cfg -B src/v8/dss_capi_v8.lpr
+bash custom_link.sh lib/linux_x64/v8
 
 if [ -n "$TRAVIS_TAG" ]; then
     mkdir -p release/dss_capi/

--- a/build_macos_x64.sh
+++ b/build_macos_x64.sh
@@ -6,6 +6,7 @@ if [ ! -d "build/units_v7_x64" ]; then
     mkdir build/units_v7_x64
 fi
 fpc -Px86_64 @src/v7/darwin-x64.cfg -B src/v7/dss_capi_v7.lpr
+bash custom_link.sh lib/darwin_x64/v7
 
 # Make the lib look in the same folder for KLUSolve
 DSS_CAPI_LIB="lib/darwin_x64/v7/libdss_capi_v7.dylib"
@@ -18,7 +19,7 @@ if [ ! -d "build/units_v8_x64" ]; then
     mkdir build/units_v8_x64
 fi
 fpc -Px86_64 @src/v8/darwin-x64.cfg -B src/v8/dss_capi_v8.lpr
-
+bash custom_link.sh lib/darwin_x64/v8
 
 DSS_CAPI_LIB="lib/darwin_x64/v8/libdss_capi_v8.dylib"
 CURRENT_LIBKLUSOLVE=`otool -L "$DSS_CAPI_LIB" | grep libklusolve | cut -f 1 -d ' ' | sed $'s/^[ \t]*//'`

--- a/custom_link.sh
+++ b/custom_link.sh
@@ -12,7 +12,7 @@ if [[ $1 == *"linux"* ]]; then
 else
     echo '-alias_list' >> $1/link.res
     echo 'src/darwin_alias_list.txt' >> $1/link.res
-    cut -d " " -f 1 'src/darwin_alias_list.txt' >> $1/linksyms.fpc
+    cut -d " " -f 2 'src/darwin_alias_list.txt' >> $1/linksyms.fpc
 fi
 
 $1/ppas.sh

--- a/custom_link.sh
+++ b/custom_link.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Expose copies of some functions for backwards compatibility
+if [ "$#" -ne 1 ]; then
+    echo "Please pass the output path as parameter to this script"
+    exit 1
+fi
+sed -i 's/\(      LoadShapes_Set_Sinterval;\)/\1\n      LoadShapes_Set_SInterval;/' $1/link.res 
+sed -i 's/\(      LoadShapes_Get_sInterval;\)/\1\n      LoadShapes_Get_SInterval;/' $1/link.res 
+sed -i 's/\(^VERSION$\)/LoadShapes_Set_SInterval = LoadShapes_Set_Sinterval;\nLoadShapes_Get_SInterval = LoadShapes_Get_sInterval;\n\1/' $1/link.res 
+
+$1/ppas.sh

--- a/custom_link.sh
+++ b/custom_link.sh
@@ -4,8 +4,15 @@ if [ "$#" -ne 1 ]; then
     echo "Please pass the output path as parameter to this script"
     exit 1
 fi
-sed -i 's/\(      LoadShapes_Set_Sinterval;\)/\1\n      LoadShapes_Set_SInterval;/' $1/link.res 
-sed -i 's/\(      LoadShapes_Get_sInterval;\)/\1\n      LoadShapes_Get_SInterval;/' $1/link.res 
-sed -i 's/\(^VERSION$\)/LoadShapes_Set_SInterval = LoadShapes_Set_Sinterval;\nLoadShapes_Get_SInterval = LoadShapes_Get_sInterval;\n\1/' $1/link.res 
+
+if [[ $1 == *"linux"* ]]; then
+    sed -i 's/\(      LoadShapes_Set_Sinterval;\)/\1\n      LoadShapes_Set_SInterval;/' $1/link.res 
+    sed -i 's/\(      LoadShapes_Get_sInterval;\)/\1\n      LoadShapes_Get_SInterval;/' $1/link.res 
+    sed -i 's/\(^VERSION$\)/LoadShapes_Set_SInterval = LoadShapes_Set_Sinterval;\nLoadShapes_Get_SInterval = LoadShapes_Get_sInterval;\n\1/' $1/link.res 
+else
+    echo '-alias_list' >> $1/link.res
+    echo 'src/darwin_alias_list.txt' >> $1/link.res
+    cut -d " " -f 1 'src/darwin_alias_list.txt' >> $1/linksyms.fpc
+fi
 
 $1/ppas.sh

--- a/include/v7/dss_capi.h
+++ b/include/v7/dss_capi.h
@@ -2713,7 +2713,18 @@ extern "C" {
     */
     DSS_CAPI_V7_DLL double LoadShapes_Get_MinInterval(void);
 
-    DSS_CAPI_V7_DLL double LoadShapes_Get_sInterval(void);
+    /*
+    Fixed interval data time interval, seconds
+    */
+    DSS_CAPI_V7_DLL double LoadShapes_Get_SInterval(void);
+    
+    /*
+    Fixed interval data time interval, seconds
+    */
+    DSS_CAPI_V7_DLL void LoadShapes_Set_SInterval(double Value);
+    
+    DSS_CAPI_V7_DLL double LoadShapes_Get_sInterval(void); // deprecated, see #24
+    DSS_CAPI_V7_DLL void LoadShapes_Set_Sinterval(double Value); // deprecated, see #24
 
     /*
     Fixed interval time value, hours.
@@ -2725,10 +2736,6 @@ extern "C" {
     */
     DSS_CAPI_V7_DLL void LoadShapes_Set_MinInterval(double Value);
 
-    /*
-    Fixed interval data time interval, seconds
-    */
-    DSS_CAPI_V7_DLL void LoadShapes_Set_Sinterval(double Value);
 
     DSS_CAPI_V7_DLL int32_t LoadShapes_New(char* Name);
 

--- a/include/v8/dss_capi.h
+++ b/include/v8/dss_capi.h
@@ -2662,7 +2662,18 @@ extern "C" {
     */
     DSS_CAPI_V8_DLL double LoadShapes_Get_MinInterval(void);
 
-    DSS_CAPI_V8_DLL double LoadShapes_Get_sInterval(void);
+    /*
+    Fixed interval data time interval, seconds
+    */
+    DSS_CAPI_V8_DLL double LoadShapes_Get_SInterval(void);
+    
+    /*
+    Fixed interval data time interval, seconds
+    */
+    DSS_CAPI_V8_DLL void LoadShapes_Set_SInterval(double Value);
+    
+    DSS_CAPI_V8_DLL double LoadShapes_Get_sInterval(void); // deprecated, see #24
+    DSS_CAPI_V8_DLL void LoadShapes_Set_Sinterval(double Value); // deprecated, see #24
 
     /*
     Fixed interval time value, hours.
@@ -2673,11 +2684,6 @@ extern "C" {
     Fixed Interval time value, in minutes
     */
     DSS_CAPI_V8_DLL void LoadShapes_Set_MinInterval(double Value);
-
-    /*
-    Fixed interval data time interval, seconds
-    */
-    DSS_CAPI_V8_DLL void LoadShapes_Set_Sinterval(double Value);
 
     DSS_CAPI_V8_DLL int32_t LoadShapes_New(char* Name);
 

--- a/src/darwin_alias_list.txt
+++ b/src/darwin_alias_list.txt
@@ -1,2 +1,2 @@
-_LoadShapes_Set_SInterval _LoadShapes_Set_Sinterval
-_LoadShapes_Get_SInterval _LoadShapes_Get_sInterval
+_LoadShapes_Set_Sinterval _LoadShapes_Set_SInterval
+_LoadShapes_Get_sInterval _LoadShapes_Get_SInterval

--- a/src/darwin_alias_list.txt
+++ b/src/darwin_alias_list.txt
@@ -1,0 +1,2 @@
+_LoadShapes_Set_SInterval _LoadShapes_Set_Sinterval
+_LoadShapes_Get_SInterval _LoadShapes_Get_sInterval

--- a/src/v7/darwin-x64.cfg
+++ b/src/v7/darwin-x64.cfg
@@ -28,3 +28,4 @@
 -k-lc 
 -k-lm 
 -k-lklusolve
+-sh

--- a/src/v7/dss_capi_v7.lpr
+++ b/src/v7/dss_capi_v7.lpr
@@ -794,9 +794,13 @@ exports
     LoadShapes_Get_HrInterval,
     LoadShapes_Get_MinInterval,
     LoadShapes_Get_sInterval,
+    LoadShapes_Set_Sinterval,
+{$IFDEF MSWINDOWS}
+    LoadShapes_Get_SInterval,
+    LoadShapes_Set_SInterval,
+{$ENDIF}
     LoadShapes_Set_HrInterval,
     LoadShapes_Set_MinInterval,
-    LoadShapes_Set_Sinterval,
     LoadShapes_Get_PBase,
     LoadShapes_Get_Qbase,
     LoadShapes_Set_PBase,

--- a/src/v7/linux-x64.cfg
+++ b/src/v7/linux-x64.cfg
@@ -29,3 +29,4 @@
 -k-Llib/linux_x64
 -k-lklusolve
 -k-R$ORIGIN/.
+-sh

--- a/src/v8/darwin-x64.cfg
+++ b/src/v8/darwin-x64.cfg
@@ -29,3 +29,4 @@
 -k-lc 
 -k-lm 
 -k-lklusolve
+-sh

--- a/src/v8/dss_capi_v8.lpr
+++ b/src/v8/dss_capi_v8.lpr
@@ -801,9 +801,13 @@ exports
     LoadShapes_Get_HrInterval,
     LoadShapes_Get_MinInterval,
     LoadShapes_Get_sInterval,
+    LoadShapes_Set_Sinterval,
+{$IFDEF MSWINDOWS}
+    LoadShapes_Get_SInterval,
+    LoadShapes_Set_SInterval,
+{$ENDIF}
     LoadShapes_Set_HrInterval,
     LoadShapes_Set_MinInterval,
-    LoadShapes_Set_Sinterval,
     LoadShapes_Get_PBase,
     LoadShapes_Get_Qbase,
     LoadShapes_Set_PBase,

--- a/src/v8/linux-x64.cfg
+++ b/src/v8/linux-x64.cfg
@@ -30,3 +30,4 @@
 -k-Llib/linux_x64
 -k-lklusolve
 -k-R$ORIGIN/.
+-sh


### PR DESCRIPTION
Different approaches per OS:
- On Windows, listing the same function with different casing exports them both with the casing from the exports block. This is listed as the expected behavior in the FPC docs.
- On Linux, patch the linker scripts to export aliases of the symbols in the global sections, otherwise they get stripped.
- On MacOS, patch the link scripts to use an alias-list, and append the symbols to the export list.

Closes #24 